### PR TITLE
wptrunner: Pass --enable-features=GenericSensorExtraClasses to Chrome by default

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -91,6 +91,9 @@ def executor_kwargs(logger, test_type, test_environment, run_info_data,
     # on Linux as it hasn't shipped there yet, but in WPT we enable virtual
     # authenticator devices anyway for testing and so SPC works.
     chrome_options["args"].append("--enable-features=SecurePaymentConfirmationBrowser")
+    # The GenericSensorExtraClasses flag enables the browser-side
+    # implementation of sensors such as Ambient Light Sensor.
+    chrome_options["args"].append("--enable-features=GenericSensorExtraClasses")
 
     # Classify `http-private`, `http-public` and https variants in the
     # appropriate IP address spaces.


### PR DESCRIPTION
This is required for ALS tests to pass without requiring extra arguments to be passed to `wpt run`.